### PR TITLE
Fix deprecation, make docs consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *cmake-build*
+renumerate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+renumerate:
+	cc renumerate.c -framework IOKit -framework CoreFoundation -o renumerate
+clean:
+	rm renumerate

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Application for resetting USB devices on macOS. Borrowed from USB Prober app.
 
 The available options are as follows.  If no option is specified the values after the options are assumed to be a
 sequence of vendorID,productID pairs (in hex).  If the `-l` option is specified, the values after the options are assumed
-to be locationID's (in hex).  If no action option is specitied, a reenumerate command will be sent to the device(s):
+to be locationID's (in hex).  If no action option is specitied, a renumerate command will be sent to the device(s):
 ```
 --locationID, -l
 	 The values after the options are locationIDs, instead of vendorID,productID.
@@ -34,18 +34,16 @@ Reset device at vid: 0x0488, pid: 0x5740
 
 Set the configuration of the device at vid: 0x05ac, pid: 0x1126 to 1:
 ```
-$ reenumerate -v -c 1 0x05ac,0x1126
+$ renumerate -v -c 1 0x05ac,0x1126
 
-Reenumerate the devices at locationIDs 0xfa144300 and 0xfd141310
+Renumerate the devices at locationIDs 0xfa144300 and 0xfd141310
 
-$ reenumerate -v -l 0xfa144300 0xfd141310
+$ renumerate -v -l 0xfa144300 0xfd141310
 ```
 
 # Compiling
 
-Either use CMake or 
-
-`cc reenumerate.c -framework IOKit -framework CoreFoundation -o reenumerate`
+Either use CMake or `make`
 
 # Installing
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ to be locationID's (in hex).  If no action option is specitied, a renumerate com
 --help, -h, -?
 	 Show this help.
 ```
+
+One can determine vendor, product, and location IDs with
+
+```
+system_profiler SPUSBDataType
+```
+
 # Examples
 Reset device at vid: 0x0488, pid: 0x5740
 

--- a/renumerate.c
+++ b/renumerate.c
@@ -401,7 +401,7 @@ int main(int argc, const char *argv[] )
 
     }
 
-    kr = IOServiceGetMatchingServices(kIOMasterPortDefault,matchingDict, &foundDevices);	//consumes matchingDict reference
+    kr = IOServiceGetMatchingServices(kIOMainPortDefault,matchingDict, &foundDevices);	//consumes matchingDict reference
     matchingDict = NULL;
     if(kr)
     {


### PR DESCRIPTION
This PR:

* Renames kIOMasterPortDefault to kIOMainPortDefault (fixes deprecation warning)
* Adds a makefile
* Settles on `renumerate` instead of `reenumerate` in readme, source, binary name
* Adds a note as to how to get vendor/location/product IDs

Feel free to drop any commits you don't like of course